### PR TITLE
feat: remove mapping requirement

### DIFF
--- a/src/functions/write/outbound-edi/handler.ts
+++ b/src/functions/write/outbound-edi/handler.ts
@@ -80,8 +80,14 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
       },
     };
 
+    // TODO: optionally iterate through transaction sets and translate each one
+    //  (multiple transaction sets will hopefully be supported for `/x12/from-json` soon)
+    if (event.transactionSets.length !== 1) {
+      return failedExecution(executionId, new Error("writing requires exactly one transaction set at this time"));
+    }
+
     // Translate the Guide schema-based JSON to X12 EDI
-    const translation = await translateJsonToEdi({ transactionSets: event.transactionSets }, guideId, envelope);
+    const translation = await translateJsonToEdi(event.transactionSets[0], guideId, envelope);
 
     // Save generated X12 EDI file to SFTP-accessible Bucket
     const putCommandArgs: PutObjectCommandInput = {

--- a/src/setup/deploy.ts
+++ b/src/setup/deploy.ts
@@ -29,8 +29,9 @@ const createOrUpdateFunction = async (
   const functionPaths = getFunctionPaths(process.argv[2]);
 
   // Ensure that required guides and mappings env vars are defined for all enabled transactions
-  const enabledTransactionSets = getEnabledTransactionSets();
-  getResourceIdsForTransactionSets(enabledTransactionSets);
+  // NOTE: check disabled because mappings are not used
+  // const enabledTransactionSets = getEnabledTransactionSets();
+  // getResourceIdsForTransactionSets(enabledTransactionSets);
 
   const promises = functionPaths.map(async (fnPath) => {
     const functionName = functionNameFromPath(fnPath);


### PR DESCRIPTION
- remove mapping calls from write handler function
- add `TODO` notes regarding hardcoded values
- removed env var checks during function deployment (as there won't be any mapping IDs required)

When going through the setup, you can skip the `create-guides` (you already created it) and `create-maps` (you don't need any) steps. Again, a lot of the code in these demo repos is just intended to help folks get up and running, and is pretty generic in nature. Since your usage pattern is a bit different we can adjust a bit.

To use this function for writing in your environment, you will need to add some metadata to the event you pass in (in addition to the JSON schema-formatted input to match your guide). For example, to generate a 4010-315, it should look like the following:

```typescript
{
  "ediMetadata": {
      "release": "4010",
      "code": "315"
  },
  "transactionSets": [
    // ...
  ]
}
```

You'll notice in the changes in this PR that I also added two `TODO` notes [[1](https://github.com/wregan7265/write-edi-demo/compare/main...wregan7265:write-edi-demo:rob/remove-mapping-requirement?expand=1#diff-b148e9871789071c3603979b2046d865ecb3127b7f8900c015c4e79e93417fccR36), [2](https://github.com/wregan7265/write-edi-demo/compare/main...wregan7265:write-edi-demo:rob/remove-mapping-requirement?expand=1#diff-b148e9871789071c3603979b2046d865ecb3127b7f8900c015c4e79e93417fccR60)] regarding IDs / usage codes in the handler source. The demo uses some hardcoded values to get folks up and running quickly, but you should replace those values to use the ones required by your trading partner(s). As I said, it might make sense to add something to the input shape above for this. Perhaps a `tradingPartner` property that includes sender/receiver IDs and functional codes, etc.?

I added another `TODO` note [[3](https://github.com/wregan7265/write-edi-demo/pull/1/files#diff-b148e9871789071c3603979b2046d865ecb3127b7f8900c015c4e79e93417fccR83)] regarding input transaction set length. Currently the `x12/from-json` endpoint only works for a single transaction at a time (this will hopefully change soon). I suspect you only need 1 transaction set at a time, so it's not an issue, but wanted to mention it just in case.

Lastly, before deploying, you should manually add variables to your `.env` file for each guide(s) you want to use. The env var names should use the pattern: `X12_${release}_${transactionSet}_GUIDE_ID`, such as:

```bash
X12_4010_315_GUIDE_ID=01GGSS0Y35DN7M3D8CV7884AYZ
```

... you can also set these env vars via the Functions UI after deploying if preferred. The `write-outbound-edi` function uses this pattern to identify the guide to pass along to EDI Translate.

Hope this helps, and don't hesitate to let us know if you have any questions!